### PR TITLE
Add interview export web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# principal
-principal
+# Clinyco - Generador de entrevistas
+
+Aplicación web sencilla en español para registrar la información obtenida en una entrevista clínica y generar automáticamente un archivo de texto descargable con el resumen.
+
+## ¿Cómo usarla?
+
+1. Abre `public/index.html` en tu navegador (puedes hacer doble click sobre el archivo o servirlo con cualquier servidor estático).
+2. Completa los campos de la entrevista.
+3. La vista previa mostrará el contenido del archivo de texto.
+4. Pulsa **Generar archivo** para descargar el `.txt` o **Copiar texto** para tenerlo en el portapapeles.
+
+Todos los datos se procesan en tu navegador, sin enviar información a servidores externos.
+
+## Servir la aplicación localmente
+
+Si prefieres usar un servidor estático, puedes hacerlo con `npx serve` (Node.js) desde la carpeta del proyecto:
+
+```bash
+npx serve public
+```
+
+Luego abre la URL indicada (por defecto http://localhost:3000) para ver la aplicación.

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Registro de Entrevistas | Clinyco</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Registro de entrevistas Clinyco</h1>
+      <p class="subtitle">
+        Completa la información de la entrevista y descarga un archivo de texto
+        con el resumen automáticamente.
+      </p>
+    </header>
+
+    <main class="app">
+      <section class="card">
+        <h2>Datos de la entrevista</h2>
+        <form id="interview-form" class="form-grid">
+          <label class="field">
+            <span>Nombre del paciente</span>
+            <input type="text" name="paciente" required placeholder="Ej: Juan Pérez" />
+          </label>
+
+          <label class="field">
+            <span>Profesional</span>
+            <input type="text" name="profesional" required placeholder="Ej: Dra. Soto" />
+          </label>
+
+          <label class="field">
+            <span>Fecha</span>
+            <input type="date" name="fecha" required />
+          </label>
+
+          <label class="field">
+            <span>Tipo de entrevista</span>
+            <input type="text" name="tipo" placeholder="Evaluación inicial, control, etc." />
+          </label>
+
+          <label class="field field--full">
+            <span>Motivo de consulta</span>
+            <textarea
+              name="motivo"
+              rows="3"
+              placeholder="Describe brevemente el motivo de la entrevista"
+            ></textarea>
+          </label>
+
+          <label class="field field--full">
+            <span>Resumen / Hallazgos principales</span>
+            <textarea
+              name="resumen"
+              rows="6"
+              placeholder="Redacta los puntos más importantes que se conversaron"
+              required
+            ></textarea>
+          </label>
+
+          <label class="field field--full">
+            <span>Próximos pasos</span>
+            <textarea
+              name="proximos"
+              rows="3"
+              placeholder="Indica tareas, derivaciones o próximos controles"
+            ></textarea>
+          </label>
+
+          <div class="form-actions">
+            <button type="button" id="clear-btn" class="btn btn-secondary">Limpiar</button>
+            <button type="submit" class="btn btn-primary">Generar archivo</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="card">
+        <div class="card-header">
+          <h2>Vista previa del archivo</h2>
+          <div class="preview-actions">
+            <button id="copy-btn" class="btn btn-secondary" type="button">Copiar texto</button>
+            <a id="download-btn" class="btn btn-primary" href="#" download>Descargar TXT</a>
+          </div>
+        </div>
+        <textarea id="preview" class="preview" readonly placeholder="La vista previa aparecerá aquí..."></textarea>
+      </section>
+    </main>
+
+    <footer class="app-footer">
+      <p>
+        Hecho con ❤️ para el equipo de <strong>Clinyco</strong>. Este archivo se genera
+        completamente en tu navegador, sin enviar datos a servidores externos.
+      </p>
+    </footer>
+
+    <script src="main.js"></script>
+  </body>
+</html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,112 @@
+const form = document.getElementById("interview-form");
+const previewEl = document.getElementById("preview");
+const downloadBtn = document.getElementById("download-btn");
+const copyBtn = document.getElementById("copy-btn");
+const clearBtn = document.getElementById("clear-btn");
+
+const formatDate = (rawDate) => {
+  if (!rawDate) return "";
+  try {
+    const date = new Date(rawDate);
+    return new Intl.DateTimeFormat("es-CL", {
+      dateStyle: "long",
+    }).format(date);
+  } catch (error) {
+    return rawDate;
+  }
+};
+
+const buildText = (data) => {
+  const lines = [
+    `Paciente: ${data.paciente || ""}`,
+    `Profesional: ${data.profesional || ""}`,
+    `Fecha: ${formatDate(data.fecha)}`,
+  ];
+
+  if (data.tipo) {
+    lines.push(`Tipo de entrevista: ${data.tipo}`);
+  }
+
+  lines.push("".padEnd(40, "-"));
+
+  if (data.motivo) {
+    lines.push("Motivo de consulta:");
+    lines.push(data.motivo.trim());
+    lines.push("");
+  }
+
+  if (data.resumen) {
+    lines.push("Resumen / Hallazgos principales:");
+    lines.push(data.resumen.trim());
+    lines.push("");
+  }
+
+  if (data.proximos) {
+    lines.push("Próximos pasos:");
+    lines.push(data.proximos.trim());
+  }
+
+  lines.push("".padEnd(40, "-"));
+  lines.push("Generado con Clinyco - Registro de entrevistas");
+
+  return lines.join("\n");
+};
+
+let currentObjectUrl = null;
+
+const syncPreview = () => {
+  const formData = new FormData(form);
+  const data = Object.fromEntries(formData.entries());
+  const text = buildText(data);
+  previewEl.value = text;
+
+  const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
+  if (currentObjectUrl) {
+    URL.revokeObjectURL(currentObjectUrl);
+  }
+  const fileNameParts = [
+    "clinyco",
+    data.paciente?.trim().replace(/\s+/g, "-") || "paciente",
+    data.fecha || new Date().toISOString().slice(0, 10),
+  ];
+  const fileName = `${fileNameParts.join("_")}.txt`;
+  currentObjectUrl = URL.createObjectURL(blob);
+  downloadBtn.download = fileName;
+  downloadBtn.href = currentObjectUrl;
+};
+
+form.addEventListener("input", syncPreview);
+form.addEventListener("submit", (event) => {
+  event.preventDefault();
+  syncPreview();
+  downloadBtn.click();
+});
+
+copyBtn.addEventListener("click", async () => {
+  if (!previewEl.value) return;
+  try {
+    await navigator.clipboard.writeText(previewEl.value);
+    copyBtn.textContent = "¡Copiado!";
+    copyBtn.disabled = true;
+    setTimeout(() => {
+      copyBtn.textContent = "Copiar texto";
+      copyBtn.disabled = false;
+    }, 2000);
+  } catch (error) {
+    alert("No se pudo copiar el texto. Puedes copiarlo manualmente.");
+  }
+});
+
+clearBtn.addEventListener("click", () => {
+  form.reset();
+  syncPreview();
+  form.querySelector("input")?.focus();
+});
+
+syncPreview();
+
+window.addEventListener("beforeunload", () => {
+  if (currentObjectUrl) {
+    URL.revokeObjectURL(currentObjectUrl);
+  }
+});

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,192 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  --primary: #2563eb;
+  --primary-dark: #1d4ed8;
+  --secondary: #64748b;
+  --bg: #f8fafc;
+  --card-bg: #ffffff;
+  --border: #e2e8f0;
+  --text: #0f172a;
+  --muted: #475569;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.app-header,
+.app-footer {
+  padding: 2rem 1.5rem;
+  text-align: center;
+  background: var(--card-bg);
+  border-bottom: 1px solid var(--border);
+}
+
+.app-footer {
+  border-top: 1px solid var(--border);
+  border-bottom: none;
+  margin-top: 3rem;
+}
+
+.subtitle {
+  margin: 0.75rem auto 0;
+  max-width: 680px;
+  color: var(--muted);
+}
+
+.app {
+  max-width: 1100px;
+  margin: 2rem auto;
+  display: grid;
+  gap: 1.5rem;
+  padding: 0 1.5rem;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 18px;
+  box-shadow: 0 12px 24px -16px rgba(15, 23, 42, 0.35);
+  border: 1px solid var(--border);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.card-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.field span {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.field--full {
+  grid-column: 1 / -1;
+}
+
+input,
+textarea {
+  font: inherit;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background-color: #f9fafb;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  resize: vertical;
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+}
+
+textarea.preview {
+  min-height: 320px;
+  width: 100%;
+  border-radius: 12px;
+  padding: 1rem;
+  background-color: #0f172a;
+  color: #f8fafc;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+}
+
+.form-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: 12px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn-primary {
+  background: linear-gradient(120deg, var(--primary) 0%, var(--primary-dark) 100%);
+  color: white;
+  box-shadow: 0 12px 24px -12px rgba(37, 99, 235, 0.6);
+}
+
+.btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 30px -15px rgba(37, 99, 235, 0.75);
+}
+
+.btn-secondary {
+  background: #e2e8f0;
+  color: var(--text);
+}
+
+.btn-secondary:hover {
+  background: #cbd5f5;
+}
+
+.preview-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+@media (max-width: 720px) {
+  .app {
+    margin: 1.5rem auto;
+  }
+
+  .card {
+    padding: 1.5rem;
+  }
+
+  .card-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .preview-actions {
+    width: 100%;
+  }
+
+  .preview-actions .btn {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- build a browser-based form to capturar datos de entrevistas y generar un archivo de texto descargable
- add controles para copiar, limpiar y previsualizar el contenido generado
- documentar el flujo de uso y opciones para servir la aplicación localmente

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_b_68d5da3d2eb883299fbb8154af3ca0e9