### PR TITLE
Add FastAPI patient summary pipeline API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
-# principal
-principal
+# Principal Patient Summary Service
+
+This project exposes a small FastAPI application that can generate, revise, and
+inspect patient intake summaries. It uses a deterministic template-based
+summarizer and an in-memory store to keep track of each revision.
+
+## Getting started
+
+1. Install the dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Launch the API server:
+
+   ```bash
+   uvicorn app.api:app --reload
+   ```
+
+   The service listens on `http://127.0.0.1:8000` by default. Interactive API
+documentation is available at `/docs`.
+
+## Available endpoints
+
+| Method & Path | Description |
+| --- | --- |
+| `POST /summaries/propose` | Accepts `PatientIntakeData` JSON and returns a generated `SummaryVersion`. |
+| `POST /summaries/{intake_id}/revise` | Records a revision, storing clinician notes and optional updated summary text. |
+| `GET /summaries/{intake_id}/diffs` | Provides unified diffs between consecutive summary versions. |
+| `GET /corpus` | Exposes the stored corpus for model training or audit workflows. |
+
+## Data contracts
+
+### PatientIntakeData
+
+```json
+{
+  "intake_id": "unique-string",
+  "patient_name": "Ada Lovelace",
+  "age": 36,
+  "chief_complaint": "Headache",
+  "history": "Optional historical context",
+  "medications": "Optional medication list"
+}
+```
+
+### SummaryRevisionRequest
+
+```json
+{
+  "intake_id": "unique-string",
+  "notes": "Clinician notes explaining the revision",
+  "summary_text": "Optional updated summary text"
+}
+```
+
+The `/corpus` endpoint returns an array of objects combining intake data,
+summary text, and notes for every stored version, making it suitable for
+collecting training data for downstream models.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application package for patient summary service."""

--- a/app/api.py
+++ b/app/api.py
@@ -1,0 +1,66 @@
+"""FastAPI routes exposing the patient summary pipeline."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import Body, FastAPI, HTTPException, Path
+from pydantic import BaseModel
+
+from .models import PatientIntakeData, SummaryVersion
+from .pipeline import PatientSummaryPipeline
+from .store import SummaryStore
+from .summarizer import TemplateSummarizer
+
+app = FastAPI(title="Patient Summary Service", version="1.0.0")
+
+pipeline = PatientSummaryPipeline(summarizer=TemplateSummarizer(), store=SummaryStore())
+
+
+class SummaryRevisionRequest(BaseModel):
+    """Request payload when recording a revision to an existing summary."""
+
+    intake_id: str
+    notes: str
+    summary_text: Optional[str] = None
+
+
+@app.post("/summaries/propose", response_model=SummaryVersion)
+async def propose_summary(intake: PatientIntakeData) -> SummaryVersion:
+    """Generate a new summary draft for the supplied intake information."""
+
+    return pipeline.propose_summary(intake)
+
+
+@app.post("/summaries/{intake_id}/revise", response_model=SummaryVersion)
+async def revise_summary(
+    intake_id: str = Path(..., description="Identifier of the intake to revise"),
+    payload: SummaryRevisionRequest = Body(...),
+) -> SummaryVersion:
+    """Persist a revised summary version and accompanying notes."""
+
+    if intake_id != payload.intake_id:
+        raise HTTPException(status_code=400, detail="Path and payload intake IDs must match")
+    try:
+        return pipeline.revise_summary(
+            intake_id=intake_id,
+            notes=payload.notes,
+            summary_text=payload.summary_text,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@app.get("/summaries/{intake_id}/diffs")
+async def get_diffs(intake_id: str = Path(..., description="Identifier of the intake")) -> List[dict]:
+    """Retrieve line-by-line diffs between summary versions."""
+
+    if not pipeline.store.has_intake(intake_id):
+        raise HTTPException(status_code=404, detail="Intake not found")
+    return pipeline.compare_versions(intake_id)
+
+
+@app.get("/corpus")
+async def get_corpus() -> List[dict]:
+    """Return corpus entries composed of intake data and summary versions."""
+
+    return pipeline.collect_training_corpus()

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,40 @@
+"""Domain models for patient summary pipeline."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class PatientIntakeData(BaseModel):
+    """Structured representation of the data captured during patient intake."""
+
+    intake_id: str = Field(..., description="Unique identifier for the intake session")
+    patient_name: str = Field(..., description="Full name of the patient")
+    age: int = Field(..., ge=0, description="Age of the patient")
+    chief_complaint: str = Field(..., description="Primary reason for the visit")
+    history: Optional[str] = Field(
+        default="",
+        description="Pertinent medical history or context gathered during intake",
+    )
+    medications: Optional[str] = Field(
+        default="",
+        description="Current medications the patient is taking",
+    )
+
+
+class SummaryVersion(BaseModel):
+    """A single version of an automatically generated or revised summary."""
+
+    intake_id: str
+    version: int = Field(..., ge=1, description="Version number for the summary")
+    summary_text: str
+    notes: Optional[str] = Field(
+        default=None,
+        description="Reviewer or clinician notes associated with the revision",
+    )
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        description="Timestamp recording when this version was created",
+    )

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -1,0 +1,82 @@
+"""Patient summary orchestration pipeline."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from .models import PatientIntakeData, SummaryVersion
+from .store import SummaryStore
+from .summarizer import BaseSummarizer
+
+
+class PatientSummaryPipeline:
+    """Coordinates summarization, storage, and analytics for patient intakes."""
+
+    def __init__(self, summarizer: BaseSummarizer, store: Optional[SummaryStore] = None) -> None:
+        self.summarizer = summarizer
+        self.store = store or SummaryStore()
+
+    def propose_summary(self, intake: PatientIntakeData) -> SummaryVersion:
+        """Generate and persist a summary for the provided intake data."""
+
+        summary_text = self.summarizer.summarize(intake)
+        return self.store.add_version(intake=intake, summary_text=summary_text)
+
+    def revise_summary(
+        self,
+        intake_id: str,
+        notes: str,
+        summary_text: Optional[str] = None,
+    ) -> SummaryVersion:
+        """Record a revised summary, optionally overriding the generated text."""
+
+        latest = self.store.get_latest(intake_id)
+        if latest is None:
+            raise ValueError(f"No intake data found for '{intake_id}'")
+
+        intake_data = self.store.get_intake_data(intake_id)
+        assert intake_data is not None  # for type checkers
+
+        new_summary_text = summary_text or latest.summary_text
+        return self.store.add_version(intake=intake_data, summary_text=new_summary_text, notes=notes)
+
+    def compare_versions(self, intake_id: str) -> List[Dict[str, object]]:
+        """Produce diffs between consecutive summary versions for the intake."""
+
+        import difflib
+
+        versions = self.store.get_versions(intake_id)
+        diffs: List[Dict[str, object]] = []
+        for previous, current in zip(versions, versions[1:]):
+            diff = "\n".join(
+                difflib.unified_diff(
+                    previous.summary_text.splitlines(),
+                    current.summary_text.splitlines(),
+                    fromfile=f"version {previous.version}",
+                    tofile=f"version {current.version}",
+                    lineterm="",
+                )
+            )
+            diffs.append(
+                {
+                    "from_version": previous.version,
+                    "to_version": current.version,
+                    "diff": diff,
+                }
+            )
+        return diffs
+
+    def collect_training_corpus(self) -> List[Dict[str, object]]:
+        """Collect summaries and intake data for model fine-tuning."""
+
+        corpus: List[Dict[str, object]] = []
+        for intake_id, record in self.store.iter_all():
+            corpus.append(
+                {
+                    "intake_id": intake_id,
+                    "version": record.version,
+                    "summary_text": record.summary_text,
+                    "notes": record.notes,
+                    "intake_data": record.intake_data.dict(),
+                }
+            )
+        return corpus

--- a/app/store.py
+++ b/app/store.py
@@ -1,0 +1,76 @@
+"""In-memory persistence for patient summary versions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Iterable, List, Optional
+
+from .models import PatientIntakeData, SummaryVersion
+
+
+@dataclass
+class _StoredSummary:
+    """Internal representation of a stored summary version."""
+
+    version: int
+    summary_text: str
+    notes: Optional[str]
+    created_at: datetime
+    intake_data: PatientIntakeData
+
+    def to_model(self, intake_id: str) -> SummaryVersion:
+        return SummaryVersion(
+            intake_id=intake_id,
+            version=self.version,
+            summary_text=self.summary_text,
+            notes=self.notes,
+            created_at=self.created_at,
+        )
+
+
+class SummaryStore:
+    """Simple in-memory store for patient summary versions."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, List[_StoredSummary]] = {}
+
+    def add_version(
+        self,
+        intake: PatientIntakeData,
+        summary_text: str,
+        notes: Optional[str] = None,
+    ) -> SummaryVersion:
+        versions = self._store.setdefault(intake.intake_id, [])
+        version_number = len(versions) + 1
+        record = _StoredSummary(
+            version=version_number,
+            summary_text=summary_text,
+            notes=notes,
+            created_at=datetime.utcnow(),
+            intake_data=intake,
+        )
+        versions.append(record)
+        return record.to_model(intake.intake_id)
+
+    def get_versions(self, intake_id: str) -> List[SummaryVersion]:
+        return [record.to_model(intake_id) for record in self._store.get(intake_id, [])]
+
+    def get_latest(self, intake_id: str) -> Optional[_StoredSummary]:
+        versions = self._store.get(intake_id)
+        if not versions:
+            return None
+        return versions[-1]
+
+    def iter_all(self) -> Iterable[tuple[str, _StoredSummary]]:
+        for intake_id, versions in self._store.items():
+            for record in versions:
+                yield intake_id, record
+
+    def has_intake(self, intake_id: str) -> bool:
+        return intake_id in self._store
+
+    def get_intake_data(self, intake_id: str) -> Optional[PatientIntakeData]:
+        versions = self._store.get(intake_id)
+        if not versions:
+            return None
+        return versions[0].intake_data

--- a/app/summarizer.py
+++ b/app/summarizer.py
@@ -1,0 +1,29 @@
+"""Summarization utilities for the patient summary pipeline."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from textwrap import dedent
+
+from .models import PatientIntakeData
+
+
+class BaseSummarizer(ABC):
+    """Interface for classes capable of summarizing patient intake data."""
+
+    @abstractmethod
+    def summarize(self, intake: PatientIntakeData) -> str:
+        """Generate a textual summary for the provided intake data."""
+
+
+class TemplateSummarizer(BaseSummarizer):
+    """A deterministic summarizer that formats intake data into a template."""
+
+    def summarize(self, intake: PatientIntakeData) -> str:
+        history = intake.history.strip() or "No additional history provided."
+        medications = intake.medications.strip() or "No medications reported."
+        template = f"""
+        Patient {intake.patient_name} (age {intake.age}) presents with {intake.chief_complaint}.
+        History: {history}
+        Medications: {medications}
+        """
+        return dedent(template).strip()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi>=0.110
+uvicorn[standard]>=0.27


### PR DESCRIPTION
## Summary
- add patient intake models, in-memory store, and summarizer backing a summary pipeline
- expose FastAPI routes to propose summaries, record revisions, and retrieve diffs/corpus data
- document server usage and dependencies for running the new API

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_b_68d5fa5cd514832983345bcf66a19312